### PR TITLE
fix account holder name

### DIFF
--- a/src/AqBanking/Account.php
+++ b/src/AqBanking/Account.php
@@ -15,14 +15,21 @@ class Account implements AccountInterface, Arrayable
     private $accountNumber;
 
     /**
+     * @var string
+     */
+    private $accountHolderName;
+
+    /**
      * @param BankCode $bankCode
      * @param string $accountNumber
+     * @param string $accountHolderName
      * @return \AqBanking\Account
      */
-    public function __construct(BankCode $bankCode, $accountNumber)
+    public function __construct(BankCode $bankCode, $accountNumber, $accountHolderName = '')
     {
         $this->bankCode = $bankCode;
         $this->accountNumber = $accountNumber;
+        $this->accountHolderName = $accountHolderName;
     }
 
     /**
@@ -41,10 +48,19 @@ class Account implements AccountInterface, Arrayable
         return $this->accountNumber;
     }
 
+    /**
+     * @return string
+     */
+    public function getAccountHolderName()
+    {
+        return $this->accountHolderName;
+    }
+
     public function toArray()
     {
         return [
             'bankCode' => $this->getBankCode()->getString(),
+            'accountHolderName' => $this->getAccountHolderName(),
             'accountNumber' => $this->getAccountNumber()
         ];
     }

--- a/src/AqBanking/AccountInterface.php
+++ b/src/AqBanking/AccountInterface.php
@@ -12,5 +12,10 @@ interface AccountInterface
     /**
      * @return string
      */
+    public function getAccountHolderName();
+
+    /**
+     * @return string
+     */
     public function getAccountNumber();
 }

--- a/tests/Command/RenderContextFileToXMLCommandTest.php
+++ b/tests/Command/RenderContextFileToXMLCommandTest.php
@@ -55,4 +55,91 @@ class RenderContextFileToXMLCommandTest extends TestCase
         $this->expectException('RuntimeException');
         $sut->execute(new ContextFile('/path/to/some/context/file.ctx'));
     }
+
+    public function testCanRenderSimpleXML()
+    {
+        $shellCommandExecutorMock = \Mockery::mock('AqBanking\Command\ShellCommandExecutor');
+        $sut = new RenderContextFileToXMLCommand();
+        $sut->setShellCommandExecutor($shellCommandExecutorMock);
+
+        $shellCommandExecutorMock
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturn(
+                new Result(
+                    [file_get_contents('./tests/fixtures/test_context_file_transactions_with_type_transfer.xml')],
+                    [],
+                    0
+            ));
+
+        $simpleXML = $sut->execute(
+            new ContextFile('/path/to/some/context/file.ctx'),
+            true
+        );
+
+        $this->assertEquals(
+            'DE33123456780000000000',
+            (string)$simpleXML->accountInfoList->accountInfo->iban->value
+        );
+
+        $this->assertEquals(
+            'ASDFFFWWAA',
+            (string)$simpleXML->accountInfoList->accountInfo->bic->value
+        );
+
+        $this->assertEquals(
+            'HARALD MUSTERMANN',
+            (string)$simpleXML->accountInfoList->accountInfo->owner->value
+        );
+
+        $this->assertEquals(
+            'DE15453384569356645534',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->remoteIban->value
+        );
+
+        $this->assertEquals(
+            'DE15453384569356645534',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->remoteIban->value
+        );
+
+        $this->assertEquals(
+            'WARENHAUS GMBH',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->remoteName->value
+        );
+
+        $this->assertEquals(
+            '2174/100:EUR',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->value->value
+        );
+
+        $this->assertEquals(
+            '0',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->executionDay->value
+        );
+
+        $this->assertEquals(
+            '20220106',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->date->value
+        );
+
+        $this->assertEquals(
+            'Rechnung',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->purpose->value
+        );
+
+        $this->assertEquals(
+            'transfer',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->type->value
+        );
+
+        $this->assertEquals(
+            'pending',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->status->value
+        );
+
+        $this->assertEquals(
+            '2407',
+            (string)$simpleXML->accountInfoList->accountInfo->transactionList->transaction->uniqueId->value
+        );
+    }
 }

--- a/tests/ContextXmlRendererTest.php
+++ b/tests/ContextXmlRendererTest.php
@@ -22,11 +22,11 @@ class ContextXmlRendererTest extends TestCase
 
         $sut = new ContextXmlRenderer($domDocument);
 
-        $localAccount = new Account(new BankCode('12345678'), '404072100');
+        $localAccount = new Account(new BankCode('12345678'), '404072100', 'HARALD MUSTERMANN');
         $expectedTransactions = array(
             new Transaction(
                 $localAccount,
-                new Account(new BankCode(''), ''),
+                new Account(new BankCode(''), '', "WARENHAUS GMBH"),
                 'transfer',
                 'Rechnung',
                 null,
@@ -65,6 +65,7 @@ class ContextXmlRendererTest extends TestCase
             ));
 
         $this->assertEquals($expectedTransactions, $sut->getTransactions());
+
     }
 
     /**


### PR DESCRIPTION
I was wrong about the account holder name. It is not used by the aqbanking command. However it is being read from the CTX / XML file produced by the command. For the local and the remote account. 
I also added a test for the simple xml command.