### PR TITLE
fix regression. Balance toArray()

### DIFF
--- a/src/Balance.php
+++ b/src/Balance.php
@@ -62,7 +62,7 @@ class Balance implements Arrayable
             'value' => [
                 'amount' => $this->getValue()->getAmount(),
                 'priceUnit' => 100,
-                'currency' => $this->getValue()->getCurrency()->getName()
+                'currency' => $this->getValue()->getCurrency()->getCode(),
             ],
             'date' => $this->getDate()->format('Y-m-d')
         ];

--- a/tests/BalanceTest.php
+++ b/tests/BalanceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use AqBanking\Balance;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Balance
+ */
+class BalanceTest extends TestCase
+{
+    public function testBalance(): void
+    {
+        $date = new DateTime();
+        $sut = new Balance(
+            date: $date,
+            value: Money::EUR(10),
+            type: 'noted',
+        );
+
+        $this->assertInstanceOf(DateTimeInterface::class, $sut->getDate());
+        $this->assertInstanceOf(Money::class, $sut->getValue());
+        $this->assertSame('noted', $sut->getType());
+        $this->assertSame([
+            'type' => 'noted',
+            'value' => [
+                'amount' => '10',
+                'priceUnit' => 100,
+                'currency' => 'EUR',
+            ],
+            'date' => $date->format('Y-m-d'),
+        ], $sut->toArray());
+    }
+}


### PR DESCRIPTION
After updating moneyphp, the currency class has no longer a method `getName()`.

https://github.com/Mestrona/aqbanking-php/blob/67f80c3c9f65933af0a11089e2c18d81acecb42b/src/AqBanking/Balance.php#L65

Is now `getCode()` or type casting `(string) $this->getValue()->getCurrency()`
